### PR TITLE
async-awaitと.then()が混在⇨ネストを修正

### DIFF
--- a/components/category/PostList.vue
+++ b/components/category/PostList.vue
@@ -85,13 +85,13 @@ export default defineComponent({
 
     async function initPostList (): Promise<void> {
       state.loading = true
-      await useFetchCategoryPosts(route.value.query.c, state.current_page, state.per_page)
-        .then((response: AxiosResponseTypeArray) => {
-          state.page_max = setPaginations(response)
-          state.posts = response.data
-        }).catch(() => {
-          state.message.error = 'データの読み込みに失敗しました。'
-        })
+      try {
+        const response: AxiosResponseTypeArray = await useFetchCategoryPosts(route.value.query.c, state.current_page, state.per_page)
+        state.page_max = setPaginations(response)
+        state.posts = response.data
+      } catch {
+        state.message.error = 'データの読み込みに失敗しました。'
+      }
       state.loading = false
 
       function setPaginations (response: AxiosResponseTypeArray): number {

--- a/components/category/PostList.vue
+++ b/components/category/PostList.vue
@@ -42,7 +42,7 @@
 import { useFetch, useRoute, defineComponent, reactive, PropType, useRouter } from '@nuxtjs/composition-api'
 import { MediaBasePath, useFetchCategoryPosts } from '@/utils/api'
 import { usePageMovePost } from '@/utils/utils'
-import type { Post, Category, AxiosResponseType } from '~/types'
+import type { Post, Category, AxiosResponseTypeArray } from '~/types'
 
 type State = {
   loading: boolean;
@@ -86,7 +86,7 @@ export default defineComponent({
     async function initPostList (): Promise<void> {
       state.loading = true
       await useFetchCategoryPosts(route.value.query.c, state.current_page, state.per_page)
-        .then((response: AxiosResponseType) => {
+        .then((response: AxiosResponseTypeArray) => {
           state.page_max = setPaginations(response)
           state.posts = response.data
         }).catch(() => {
@@ -94,7 +94,7 @@ export default defineComponent({
         })
       state.loading = false
 
-      function setPaginations (response: AxiosResponseType): number {
+      function setPaginations (response: AxiosResponseTypeArray): number {
         return Math.ceil(Number(response.headers['x-wp-total']) / state.per_page)
       }
     }

--- a/components/post/PostList.vue
+++ b/components/post/PostList.vue
@@ -47,7 +47,7 @@
 import { useFetch, defineComponent, reactive, PropType, useRouter } from '@nuxtjs/composition-api'
 import { MediaBasePath, useFetchPosts } from '@/utils/api'
 import { usePageMovePost } from '@/utils/utils'
-import type { Category, Post, AxiosResponseType } from '@/types/'
+import type { Category, Post, AxiosResponseTypeArray } from '@/types/'
 
 type State = {
   loading: boolean;
@@ -91,7 +91,7 @@ export default defineComponent({
       state.loading = true
       try {
         await useFetchPosts(state.current_page, state.per_page)
-          .then((response: AxiosResponseType) => {
+          .then((response: AxiosResponseTypeArray) => {
             state.page_max = setPaginations(response)
             state.posts = response.data
           })
@@ -100,7 +100,7 @@ export default defineComponent({
       }
       state.loading = false
 
-      function setPaginations (response_data: AxiosResponseType): number {
+      function setPaginations (response_data: AxiosResponseTypeArray): number {
         return Math.ceil(Number(response_data.headers['x-wp-total']) / state.per_page)
       }
     }

--- a/components/post/PostList.vue
+++ b/components/post/PostList.vue
@@ -90,11 +90,9 @@ export default defineComponent({
     async function readPosts (): Promise<void> {
       state.loading = true
       try {
-        await useFetchPosts(state.current_page, state.per_page)
-          .then((response: AxiosResponseTypeArray) => {
-            state.page_max = setPaginations(response)
-            state.posts = response.data
-          })
+        const response: AxiosResponseTypeArray = await useFetchPosts(state.current_page, state.per_page)
+        state.page_max = setPaginations(response)
+        state.posts = response.data
       } catch {
         state.message.error = 'データの読み込みに失敗しました。'
       }

--- a/components/search/SearchBlock.vue
+++ b/components/search/SearchBlock.vue
@@ -50,7 +50,7 @@ import { useRouter, defineComponent, reactive, useFetch, ref } from '@nuxtjs/com
 import LoadingPageInner from '../common/LoadingPageInner.vue'
 import { useFetchCategories, useFetchSearchPosts } from '~/utils/api'
 import { usePageMovePost } from '~/utils/utils'
-import type { Category, SearchPost, AxiosResponseType } from '~/types'
+import type { Category, SearchPost, AxiosResponseTypeArray } from '~/types'
 
 interface StateType {
   search_query: string;
@@ -73,7 +73,7 @@ export default defineComponent({
     const categories = ref([])
     useFetch(async () => {
       try {
-        const response: AxiosResponseType = await useFetchCategories()
+        const response: AxiosResponseTypeArray = await useFetchCategories()
         categories.value = response.data
       } catch (error) {
         categories.value = []
@@ -91,7 +91,7 @@ export default defineComponent({
 
     async function search (): Promise<void> {
       state.search_loading = true
-      const response: AxiosResponseType = await useFetchSearchPosts(state.search_query)
+      const response: AxiosResponseTypeArray = await useFetchSearchPosts(state.search_query)
       state.search_items = response.data
       state.search_loading = false
     }

--- a/components/search/SearchBlock.vue
+++ b/components/search/SearchBlock.vue
@@ -73,9 +73,8 @@ export default defineComponent({
     const categories = ref([])
     useFetch(async () => {
       try {
-        await useFetchCategories().then((response) => {
-          categories.value = response.data
-        })
+        const response: AxiosResponseType = await useFetchCategories()
+        categories.value = response.data
       } catch (error) {
         categories.value = []
       }
@@ -92,10 +91,8 @@ export default defineComponent({
 
     async function search (): Promise<void> {
       state.search_loading = true
-      state.search_items = await useFetchSearchPosts(state.search_query)
-        .then((response: AxiosResponseType) => {
-          return response.data
-        })
+      const response: AxiosResponseType = await useFetchSearchPosts(state.search_query)
+      state.search_items = response.data
       state.search_loading = false
     }
 

--- a/layouts/page.vue
+++ b/layouts/page.vue
@@ -22,9 +22,7 @@ export default defineComponent({
 
     useFetch(async () => {
       try {
-        await readNavCategories().then((res) => {
-          headerCategories.value = res
-        })
+        headerCategories.value = await readNavCategories()
       } catch (error) {
         console.log(error)
       }

--- a/layouts/post.vue
+++ b/layouts/post.vue
@@ -24,7 +24,11 @@ export default defineComponent({
   setup () {
     const navCategoryList = ref<Category[]>([])
     useFetch(async () => {
-      navCategoryList.value = await readNavCategories()
+      try {
+        navCategoryList.value = await readNavCategories()
+      } catch (error) {
+        console.log(error)
+      }
     })
 
     return {

--- a/layouts/top.vue
+++ b/layouts/top.vue
@@ -18,7 +18,11 @@ export default defineComponent({
     const categoryList = ref<Category[]>([])
     // fetch
     useFetch(async () => {
-      categoryList.value = await readNavCategories()
+      try {
+        categoryList.value = await readNavCategories()
+      } catch (error) {
+        console.log(error)
+      }
     })
 
     return {

--- a/pages/_category/_post.vue
+++ b/pages/_category/_post.vue
@@ -27,15 +27,24 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent, useFetch, reactive, useRoute } from '@nuxtjs/composition-api'
 import hljs from 'highlight.js'
+import type { Post, AxiosResponsePostObject } from '@/types'
 import { useFetchPost } from '@/utils/api'
+
+interface StateType {
+  loading: boolean,
+  post: {} | Post,
+  meta: {
+    title: string
+  }
+}
 
 export default defineComponent({
   layout: 'post',
   setup () {
-    const state = reactive({
+    const state = reactive<StateType>({
       loading: false,
       post: {},
       meta: {
@@ -47,9 +56,10 @@ export default defineComponent({
     useFetch(async () => {
       state.loading = true
       try {
-        await useFetchPost(route.value.query.p).then((res) => {
-          state.post = res.data
-        })
+        if (route.value.query.p) {
+          const response: AxiosResponsePostObject = await useFetchPost(route.value.query.p)
+          state.post = response.data
+        }
       } catch (error) {
         console.log(error)
       }

--- a/pages/_category/index.vue
+++ b/pages/_category/index.vue
@@ -19,7 +19,7 @@ import { useFetch, useMeta, useRoute, useRouter } from '@nuxtjs/composition-api'
 import { defineComponent, reactive, ref } from 'vue'
 import { useFetchCategories, useFetchCategory } from '@/utils/api'
 import { useRedirectNotFount } from '@/utils/utils'
-import type { Category } from '~/types'
+import type { AxiosResponseTypeArray, Category } from '~/types'
 
 type State = {
   category: Category | null
@@ -41,12 +41,8 @@ export default defineComponent({
         return useRedirectNotFount(router)
       }
 
-      categories.value = await useFetchCategories()
-        .then(response => response.data)
-        .catch((err) => {
-          console.log(err)
-          return []
-        })
+      const responseCategories: AxiosResponseTypeArray = await useFetchCategories()
+      categories.value = responseCategories.data
 
       await useFetchCategory(route.value.query.c)
         .then((res) => {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,7 +13,7 @@ import { defineComponent, Ref, ref } from 'vue'
 import { useFetch } from '@nuxtjs/composition-api'
 import { useFetchCategories } from '~/utils/api'
 import LoadingPageInner from '~/components/common/LoadingPageInner.vue'
-import { Category } from '~/types'
+import { AxiosResponseTypeArray, Category } from '~/types'
 
 export default defineComponent({
   components: { LoadingPageInner },
@@ -25,7 +25,8 @@ export default defineComponent({
     useFetch(async () => {
       loading.value = true
       try {
-        categories.value = await useFetchCategories().then(response => response.data)
+        const response: AxiosResponseTypeArray = await useFetchCategories()
+        categories.value = response.data
       } catch (error) {
         categories.value = []
         console.log(error)

--- a/pages/sitemap.vue
+++ b/pages/sitemap.vue
@@ -51,22 +51,20 @@ export default defineComponent({
     })
 
     useFetch(async () => {
-      await useFetchCategories()
-        .then((res: AxiosResponseTypeArray) => {
-          readCategoryPosts(res.data)
-        })
-        .catch((err) => {
-          state.message.error = err
-        })
+      try {
+        const response: AxiosResponseTypeArray = await useFetchCategories()
+        readCategoryPosts(response.data)
+      } catch (error) {
+        state.message.error = error
+      }
     })
 
     function readCategoryPosts (categories: Category[]) {
       try {
         categories.filter((r: Category) => r.id !== 1)
           .forEach(async (category: Category) => {
-            await useFetchSitemapPosts(category).then((res: AxiosResponseTypeArray) => {
-              category.posts = res.data
-            })
+            const response: AxiosResponseTypeArray = await useFetchSitemapPosts(category)
+            category.posts = response.data
             state.categories.push(category)
           })
       } catch (error) {

--- a/pages/sitemap.vue
+++ b/pages/sitemap.vue
@@ -30,7 +30,7 @@
 import { defineComponent, reactive, useFetch, useMeta, useRouter } from '@nuxtjs/composition-api'
 import { useFetchCategories, useFetchSitemapPosts } from '~/utils/api'
 import { usePageMovePost } from '~/utils/utils'
-import type { Category, Post, AxiosResponseType } from '@/types/'
+import type { Category, Post, AxiosResponseTypeArray } from '@/types/'
 
 type DataType = {
   categories: Category[],
@@ -52,7 +52,7 @@ export default defineComponent({
 
     useFetch(async () => {
       await useFetchCategories()
-        .then((res: AxiosResponseType) => {
+        .then((res: AxiosResponseTypeArray) => {
           readCategoryPosts(res.data)
         })
         .catch((err) => {
@@ -64,7 +64,7 @@ export default defineComponent({
       try {
         categories.filter((r: Category) => r.id !== 1)
           .forEach(async (category: Category) => {
-            await useFetchSitemapPosts(category).then((res: AxiosResponseType) => {
+            await useFetchSitemapPosts(category).then((res: AxiosResponseTypeArray) => {
               category.posts = res.data
             })
             state.categories.push(category)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -109,9 +109,22 @@ export interface SearchPost {
   title: string;
 }
 
-export interface AxiosResponseType {
+export interface AxiosResponseTypeArray {
   config: Object;
   data: [];
+  headers: {
+    'content-type': string;
+    link: string;
+    'x-wp-total': string;
+    'x-wp-totalpages': string;
+  }
+  request: XMLHttpRequest;
+  status: number;
+  statusText: string;
+}
+export interface AxiosResponsePostObject {
+  config: Object;
+  data: Post;
   headers: {
     'content-type': string;
     link: string;

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import axios from 'axios'
 import VueAxios from 'vue-axios'
-import type { Page, Post, AxiosResponseType, AxiosResponseCategoryDataObjectType, Category } from '@/types/'
+import type { Page, AxiosResponsePostObject, AxiosResponseTypeArray, AxiosResponseCategoryDataObjectType, Category } from '@/types/'
 
 Vue.use(VueAxios, axios)
 
@@ -17,25 +17,25 @@ export async function useFetchPage (slug: string | null | undefined): Promise<Pa
   return await callGetApi(base_url + params)
 }
 
-export async function useFetchSitemapPosts (category: Category): Promise<AxiosResponseType> {
+export async function useFetchSitemapPosts (category: Category): Promise<AxiosResponseTypeArray> {
   const params: string = 'posts?categories=' + category.id + '&per_page=100'
   const base_url: string = getApiBaseUrl(WpApi)
   return await callGetApi(base_url + params)
 }
 
-export async function useFetchPosts (current_page: number, per_page: number): Promise<AxiosResponseType> {
+export async function useFetchPosts (current_page: number, per_page: number): Promise<AxiosResponseTypeArray> {
   const base_url: string = getApiBaseUrl(WpApi)
   const params: string = 'posts?_embed' + '&page=' + current_page + '&per_page=' + per_page
   return await callGetApi(base_url + params)
 }
 
-export async function useFetchCategoryPosts (route_category_id: string | (string | null)[], current_page: number, per_page: number): Promise<AxiosResponseType> {
+export async function useFetchCategoryPosts (route_category_id: string | (string | null)[], current_page: number, per_page: number): Promise<AxiosResponseTypeArray> {
   const base_url: string = getApiBaseUrl(WpApi)
   const params: string = 'posts?categories=' + route_category_id + '&_embed' + '&page=' + current_page + '&per_page=' + per_page
   return await callGetApi(base_url + params)
 }
 
-export async function useFetchSearchPosts (search_query: string): Promise<AxiosResponseType> {
+export async function useFetchSearchPosts (search_query: string): Promise<AxiosResponseTypeArray> {
   const base_url: string = getApiBaseUrl(CustomApi)
   const params: string = 'search/' + search_query
   return await callGetApi(base_url + params)
@@ -47,13 +47,13 @@ export async function useFetchCategory (category_id: string | (string | null)[])
   return await callGetApi(base_url + params)
 }
 
-export async function useFetchPost (post_id: number): Promise<Post> {
+export async function useFetchPost (post_id: string): Promise<AxiosResponsePostObject> {
   const params: string = 'posts/' + post_id + '?_embed'
   const base_url: string = getApiBaseUrl(WpApi)
   return await callGetApi(base_url + params)
 }
 
-export async function useFetchCategories (): Promise<AxiosResponseType> {
+export async function useFetchCategories (): Promise<AxiosResponseTypeArray> {
   const base_url: string = getApiBaseUrl(WpApi)
   const params: string = 'categories?per_page=20'
   return await callGetApi(base_url + params)

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -3,10 +3,8 @@ import type { Category, Post } from '@/types/'
 import { useFetchCategories } from '~/utils/api'
 
 export async function readNavCategories (): Promise<Category[]> {
-  const results: Category[] = await useFetchCategories()
-    .then((response) => {
-      return response.data.filter((v: Category) => v.id !== 14 && v.id !== 1)
-    })
+  const response = await useFetchCategories()
+  const results: Category[] = response.data.filter((v: Category) => v.id !== 14 && v.id !== 1)
   return formatCategories(results)
 }
 


### PR DESCRIPTION
## Issues

* https://github.com/waibandl321/nuxt-freelance321-com/issues/1

## やったこと

* async-await分と.then()が混在してネストが深くなっていたため修正
* TypeScriptの型修正
